### PR TITLE
Add rectangular and evenly distributed size windows

### DIFF
--- a/slidingwindow/SlidingWindow.py
+++ b/slidingwindow/SlidingWindow.py
@@ -84,48 +84,69 @@ class SlidingWindow(object):
 		return self.__str__()
 
 
-def generate(data, dimOrder, maxWindowSize, overlapPercent, transforms = []):
+def generate(data, dimOrder, windowShape, overlapPercent, transforms=[], mode='square'):
 	"""
-	Generates a set of sliding windows for the specified dataset.
-	"""
-	
+    Generates a set of sliding windows for the specified dataset.
+    WindowMode has to be one of 'sqaure', 'rectangle' or 'distribute'.
+    """
 	# Determine the dimensions of the input data
-	width = data.shape[dimOrder.index('w')]
-	height = data.shape[dimOrder.index('h')]
-	
+	imgHeight = data.shape[dimOrder.index('h')]
+	imgWidth = data.shape[dimOrder.index('w')]
+	imgShape = imgHeight, imgWidth
+
+	if mode == 'sqaure':
+
+		if not isinstance(windowShape, int):
+			raise Exception("'windowShape' has to be an integer with a single value in 'square' mode.")
+
+		windowShape = (windowShape, windowShape)
+
+	elif mode == 'rectangle':
+
+		if not isinstance(windowShape, tuple) or len(windowShape) != 2:
+			raise Exception(
+				"'windowShape' has to be a tuple with height and width of sliding window in 'rectangle' mode.")
+
+	elif mode == 'distribute':
+
+		numWindowY, numWindowX = windowShape
+
+		windowSizeY = math.ceil(imgHeight / numWindowY)
+		windowSizeX = math.ceil(imgWidth / numWindowX)
+
+		windowShape = windowSizeY, windowSizeX
+
 	# Generate the windows
-	return generateForSize(width, height, dimOrder, maxWindowSize, overlapPercent, transforms)
+	return generateForSize(windowShape, imgShape, dimOrder, overlapPercent, transforms)
 
 
-def generateForSize(width, height, dimOrder, maxWindowSize, overlapPercent, transforms = []):
+def generateForSize(windowShape, imgShape, dimOrder, overlapPercent, transforms=[]):
 	"""
 	Generates a set of sliding windows for a dataset with the specified dimensions and order.
-	"""
-	
-	# If the input data is smaller than the specified window size,
-	# clip the window size to the input size on both dimensions
-	windowSizeX = min(maxWindowSize, width)
-	windowSizeY = min(maxWindowSize, height)
-	
+    """
+
+	windowSizeY, windowSizeX = windowShape
+
 	# Compute the window overlap and step size
 	windowOverlapX = int(math.floor(windowSizeX * overlapPercent))
 	windowOverlapY = int(math.floor(windowSizeY * overlapPercent))
 	stepSizeX = windowSizeX - windowOverlapX
 	stepSizeY = windowSizeY - windowOverlapY
-	
+
 	# Determine how many windows we will need in order to cover the input data
-	lastX = width - windowSizeX
-	lastY = height - windowSizeY
-	xOffsets = list(range(0, lastX+1, stepSizeX))
-	yOffsets = list(range(0, lastY+1, stepSizeY))
-	
+	imgHeight, imgWidth = imgShape
+	lastX = imgWidth - windowSizeX
+	lastY = imgHeight - windowSizeY
+	xOffsets = list(range(0, lastX + 1, stepSizeX))
+	yOffsets = list(range(0, lastY + 1, stepSizeY))
+
 	# Unless the input data dimensions are exact multiples of the step size,
 	# we will need one additional row and column of windows to get 100% coverage
 	if len(xOffsets) == 0 or xOffsets[-1] != lastX:
 		xOffsets.append(lastX)
 	if len(yOffsets) == 0 or yOffsets[-1] != lastY:
 		yOffsets.append(lastY)
-	
+
 	# Generate the list of windows
 	windows = []
 	for xOffset in xOffsets:
@@ -139,5 +160,5 @@ def generateForSize(width, height, dimOrder, maxWindowSize, overlapPercent, tran
 					dimOrder=dimOrder,
 					transform=transform
 				))
-	
+
 	return windows


### PR DESCRIPTION
In this PR, 

'generate' and 'generateForSize' functions in SlidingWindow.py are edited to be able to create sliding windows with 'rectangular' shape and 'dividing input image with distributed size'. 

I have added three modes, 'square', 'rectangule' and 'distribute' in 'generate' functions. 

'square' mode requires an integer variable as a former variable maxWindowSize did. This mode receives one window size and returns square sliding windows as the original function did.  

'rectangle' mode requires an tuple with two variables indicating height and width like numpy functions do. This mode returns rectangular sliding windows. 

'distribute' mode requires an tuple with two variables indicating the desired numbers of windows on x and y axis. 
